### PR TITLE
Add deselectToLimit option and documentation

### DIFF
--- a/pages/javascripts/pages/home/home.html
+++ b/pages/javascripts/pages/home/home.html
@@ -1190,6 +1190,12 @@ $scope.disabledData = [
 				<td>undefined</td>
 				<td>Values of the groupby property that you want to be selectable as group</td>
 			</tr>
+			<tr>
+				<td>deselectToLimit</td>
+				<td>Boolean</td>
+				<td>false</td>
+				<td>Deselect the oldest selected element when selectionLimit is reached</td>
+			</tr>
 		</tbody>
 	</table>
 	<h2>Events</h2>

--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -125,7 +125,8 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 				styleActive: false,
 				keyboardControls: false,
 				template: '{{getPropertyForObject(option, settings.displayProp)}}',
-				searchField: '$'
+				searchField: '$',
+				deselectToLimit: false
 			};
 
 			$scope.texts = {
@@ -338,12 +339,18 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 						$scope.selectedModel.splice(findIndex($scope.selectedModel, findObj), 1);
 						$scope.externalEvents.onItemDeselect(findObj);
 						if ($scope.settings.closeOnDeselect) $scope.open = false;
-					} else if (!exists && ($scope.settings.selectionLimit === 0 || $scope.selectedModel.length < $scope.settings.selectionLimit)) {
-						$scope.selectedModel.push(finalObj);
-						$scope.externalEvents.onItemSelect(finalObj);
-						if ($scope.settings.closeOnSelect) $scope.open = false;
-						if ($scope.settings.selectionLimit > 0 && $scope.selectedModel.length === $scope.settings.selectionLimit) {
-							$scope.externalEvents.onMaxSelectionReached();
+					} else if (!exists) {
+						if ($scope.settings.selectionLimit !== 0 && $scope.settings.deselectToLimit) {
+							while ($scope.selectedModel.length >= $scope.settings.selectionLimit)
+								$scope.selectedModel.shift();
+						}
+						if ($scope.settings.selectionLimit === 0 || $scope.selectedModel.length < $scope.settings.selectionLimit) {
+							$scope.selectedModel.push(finalObj);
+							$scope.externalEvents.onItemSelect(finalObj);
+							if ($scope.settings.closeOnSelect) $scope.open = false;
+							if ($scope.settings.selectionLimit > 0 && $scope.selectedModel.length === $scope.settings.selectionLimit) {
+								$scope.externalEvents.onMaxSelectionReached();
+							}
 						}
 					}
 				}


### PR DESCRIPTION
When the option is set and an item gets selected, old items are removed
from the selected-model until the selectionLimit is reached.

This is especially handy when used with selectionLimit:1 but an Array as
selected-model, as it will then tolerate (and correctly show) models
with several selected items pre-configured while maintaining the
constraint that the user may only select one item.