### PR TITLE
Restore search-filter bidirectionality

### DIFF
--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -144,6 +144,7 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 			$scope.input = {
 				searchFilter: $scope.searchFilter || ''
 			};
+			$scope.$watch(function() { return $scope.input.searchFilter; }, function(f) { $scope.searchFilter = f; });
 
 			if (angular.isDefined($scope.settings.groupBy)) {
 				$scope.$watch('options', function(newValue) {


### PR DESCRIPTION
This makes the search-filter bidirectional again by explicitly adding a
watch from the .input.searchFilter back to .searchFilter, where the
bidirectional binding can take it up.

This solves the issue only in one direction (changes to the variable
from outside still won't propagate in), and feels needless, but works
for the purpose of the bug report.

Closes: https://github.com/myforce/angularjs-dropdown-multiselect/issues/19