### PR TITLE
Drop externalevents

### DIFF
--- a/pages/javascripts/pages/home/home.html
+++ b/pages/javascripts/pages/home/home.html
@@ -1190,6 +1190,12 @@ $scope.disabledData = [
 				<td>undefined</td>
 				<td>Values of the groupby property that you want to be selectable as group</td>
 			</tr>
+			<tr>
+				<td>deselectToLimit</td>
+				<td>Boolean</td>
+				<td>false</td>
+				<td>Deselect the oldest selected element when selectionLimit is reached</td>
+			</tr>
 		</tbody>
 	</table>
 	<h2>Events</h2>

--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -341,8 +341,9 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 						if ($scope.settings.closeOnDeselect) $scope.open = false;
 					} else if (!exists) {
 						if ($scope.settings.selectionLimit !== 0 && $scope.settings.deselectToLimit) {
-							while ($scope.selectedModel.length >= $scope.settings.selectionLimit)
-								$scope.selectedModel.shift();
+							while ($scope.selectedModel.length >= $scope.settings.selectionLimit) {
+								$scope.externalEvents.onItemDeselect($scope.selectedModel.shift());
+							}
 						}
 						if ($scope.settings.selectionLimit === 0 || $scope.selectedModel.length < $scope.settings.selectionLimit) {
 							$scope.selectedModel.push(finalObj);

--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -92,16 +92,6 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 				$event.stopImmediatePropagation();
 			};
 
-			$scope.externalEvents = {
-				onItemSelect: angular.noop,
-				onItemDeselect: angular.noop,
-				onSelectAll: angular.noop,
-				onDeselectAll: angular.noop,
-				onInitDone: angular.noop,
-				onMaxSelectionReached: angular.noop,
-				onSelectionChanged: angular.noop
-			};
-
 			$scope.settings = {
 				dynamicTitle: true,
 				scrollable: false,
@@ -171,11 +161,11 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 						}
 					});
 				}
-				$scope.externalEvents.onSelectionChanged();
+				$scope._event('onSelectionChanged')();
 			};
 
 			angular.extend($scope.settings, $scope.extraSettings || []);
-			angular.extend($scope.externalEvents, $scope.events || []);
+			$scope._event = function(evname) { return (this.events !== undefined && this.events[evname]) || angular.noop; };
 			angular.extend($scope.texts, $scope.translationTexts);
 
 			$scope.singleSelection = $scope.settings.selectionLimit === 1;
@@ -287,13 +277,13 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 			$scope.selectAll = function() {
 				var searchResult;
 				$scope.deselectAll(true);
-				$scope.externalEvents.onSelectAll();
+				$scope._event('onSelectAll')();
 
 				searchResult = $filter('filter')($scope.options, $scope.getFilter($scope.input.searchFilter));
 				angular.forEach(searchResult, function(value) {
 					$scope.setSelectedItem(value[$scope.settings.idProp], true, false);
 				});
-				$scope.externalEvents.onSelectionChanged();
+				$scope._event('onSelectionChanged')();
 				$scope.selectedGroup = null;
 			};
 
@@ -301,7 +291,7 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 				dontSendEvent = dontSendEvent || false;
 
 				if (!dontSendEvent) {
-					$scope.externalEvents.onDeselectAll();
+					$scope._event('onDeselectAll')();
 				}
 
 				if ($scope.singleSelection) {
@@ -310,7 +300,7 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 					$scope.selectedModel.splice(0, $scope.selectedModel.length);
 				}
 				if (!dontSendEvent) {
-					$scope.externalEvents.onSelectionChanged();
+					$scope._event('onSelectionChanged')();
 				}
 				$scope.selectedGroup = null;
 			};
@@ -328,7 +318,7 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 				if ($scope.singleSelection) {
 					clearObject($scope.selectedModel);
 					angular.extend($scope.selectedModel, finalObj);
-					$scope.externalEvents.onItemSelect(finalObj);
+					$scope._event('onItemSelect')(finalObj);
 					if ($scope.settings.closeOnSelect || $scope.settings.closeOnDeselect) $scope.open = false;
 				} else {
 					dontRemove = dontRemove || false;
@@ -337,26 +327,26 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 
 					if (!dontRemove && exists) {
 						$scope.selectedModel.splice(findIndex($scope.selectedModel, findObj), 1);
-						$scope.externalEvents.onItemDeselect(findObj);
+						$scope._event('onItemDeselect')(findObj);
 						if ($scope.settings.closeOnDeselect) $scope.open = false;
 					} else if (!exists) {
 						if ($scope.settings.selectionLimit !== 0 && $scope.settings.deselectToLimit) {
 							while ($scope.selectedModel.length >= $scope.settings.selectionLimit) {
-								$scope.externalEvents.onItemDeselect($scope.selectedModel.shift());
+								$scope._event('onItemDeselect')($scope.selectedModel.shift());
 							}
 						}
 						if ($scope.settings.selectionLimit === 0 || $scope.selectedModel.length < $scope.settings.selectionLimit) {
 							$scope.selectedModel.push(finalObj);
-							$scope.externalEvents.onItemSelect(finalObj);
+							$scope._event('onItemSelect')(finalObj);
 							if ($scope.settings.closeOnSelect) $scope.open = false;
 							if ($scope.settings.selectionLimit > 0 && $scope.selectedModel.length === $scope.settings.selectionLimit) {
-								$scope.externalEvents.onMaxSelectionReached();
+								$scope._event('onMaxSelectionReached')();
 							}
 						}
 					}
 				}
 				if (fireSelectionChange) {
-					$scope.externalEvents.onSelectionChanged();
+					$scope._event('onSelectionChanged')();
 				}
 				$scope.selectedGroup = null;
 			};
@@ -369,7 +359,7 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 				return findIndex($scope.selectedModel, getFindObj(id)) !== -1;
 			};
 
-			$scope.externalEvents.onInitDone();
+			$scope._event('onInitDone')();
 
 			$scope.keyDownLink = function(event) {
 				var sourceScope = angular.element(event.target).scope();

--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -125,7 +125,8 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 				styleActive: false,
 				keyboardControls: false,
 				template: '{{getPropertyForObject(option, settings.displayProp)}}',
-				searchField: '$'
+				searchField: '$',
+				deselectToLimit: false
 			};
 
 			$scope.texts = {
@@ -338,12 +339,18 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 						$scope.selectedModel.splice(findIndex($scope.selectedModel, findObj), 1);
 						$scope.externalEvents.onItemDeselect(findObj);
 						if ($scope.settings.closeOnDeselect) $scope.open = false;
-					} else if (!exists && ($scope.settings.selectionLimit === 0 || $scope.selectedModel.length < $scope.settings.selectionLimit)) {
-						$scope.selectedModel.push(finalObj);
-						$scope.externalEvents.onItemSelect(finalObj);
-						if ($scope.settings.closeOnSelect) $scope.open = false;
-						if ($scope.settings.selectionLimit > 0 && $scope.selectedModel.length === $scope.settings.selectionLimit) {
-							$scope.externalEvents.onMaxSelectionReached();
+					} else if (!exists) {
+						if ($scope.settings.selectionLimit !== 0 && $scope.settings.deselectToLimit) {
+							while ($scope.selectedModel.length >= $scope.settings.selectionLimit)
+								$scope.selectedModel.shift();
+						}
+						if ($scope.settings.selectionLimit === 0 || $scope.selectedModel.length < $scope.settings.selectionLimit) {
+							$scope.selectedModel.push(finalObj);
+							$scope.externalEvents.onItemSelect(finalObj);
+							if ($scope.settings.closeOnSelect) $scope.open = false;
+							if ($scope.settings.selectionLimit > 0 && $scope.selectedModel.length === $scope.settings.selectionLimit) {
+								$scope.externalEvents.onMaxSelectionReached();
+							}
 						}
 					}
 				}


### PR DESCRIPTION
While $scope.events is received from outside the directive using a
binding, it only got evaluated at construction time due to the
externalEvents dictionary, which was presumably created to easily
provide default noop event handlers.

This patch abolishes externalEvents and replaces it with a
$scope._events function, which does a lookup in the scope's events at
runtime, and produces a noop as a last resort.

Thus, applications using this directive can pass in an event handler
object and add or remove handlers in it at any time.

----

note that this pull request complete contains the deselectToLimit pull request,
as they wouldn't merge due to deselectToLimit's touching of events.