### PR TITLE
Accept absent / undefined selected-model

### DIFF
--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -236,7 +236,7 @@ directiveModule.directive('ngDropdownMultiselect', ['$filter', '$document', '$co
 			};
 
 			$scope.getButtonText = function() {
-				if ($scope.settings.dynamicTitle && ($scope.selectedModel.length > 0 || (angular.isObject($scope.selectedModel) && Object.keys($scope.selectedModel).length > 0))) {
+				if ($scope.settings.dynamicTitle && $scope.selectedModel !== undefined && ($scope.selectedModel.length > 0 || (angular.isObject($scope.selectedModel) && Object.keys($scope.selectedModel).length > 0))) {
 					if ($scope.settings.smartButtonMaxItems > 0) {
 						var itemsText = [];
 


### PR DESCRIPTION
The term in selected-model being undefined / absent can happen when it
is provided by a controller that works asynchronously.

Such controllers typically provide a ready-property to which the
disabled attribute needs to be linked (eg. disabled="!ready"); lacking
that, disabled="model !== undefined" should be set, or more errors
occur.