### PR TITLE
Use IIFE & reflect NPM availibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ http://myforce.github.io/angularjs-dropdown-multiselect/
 	1. Using bower: <img src="http://benschwarz.github.io/bower-badges/badge@2x.png" width="130" height="30">
 	
 		Just run `bower install myforce-angularjs-dropdown-multiselect`
-	2. Manually:
+	2. Using npm : 
+		Just run `npm install angularjs-dropdown-multiselect`
+	3. Manually:
 		You can download the `.js` file directly or clone this repository
 2. Include the file in your app
 	- `<script type="text/javascript" src="angularjs-dropdown-multiselect.js"></script>`.

--- a/src/angularjs-dropdown-multiselect.js
+++ b/src/angularjs-dropdown-multiselect.js
@@ -1,3 +1,5 @@
+(function (angular) {
+
 'use strict';
 
 var directiveModule = angular.module('angularjs-dropdown-multiselect', []);
@@ -562,3 +564,5 @@ function findIndex(collection, properties) {
 
 	return index;
 }
+
+})(angular);


### PR DESCRIPTION
Hi,

This pull request suggests to use IIFE to avoid name collision between possible global function (ie find/findIndex/etc.) and actually relfect in the home page that the package is available on NPM.

I'm suggesting this pull request here and not in the main/original repo since I see no activity for a long time and i need NPM distro anyway.
